### PR TITLE
Enabled 64 bit compression when shelving

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.398</version>
+    <version>1.490</version>
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>shelve-project-plugin</artifactId>
   <name>Shelve Project Plugin</name>
-  <version>1.4-SNAPSHOT</version>
+  <version>1.4.targz-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Shelve+Project+Plugin</url>
 

--- a/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectExecutable.java
+++ b/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectExecutable.java
@@ -4,6 +4,7 @@ import hudson.FilePath;
 import hudson.model.AbstractProject;
 import hudson.model.Hudson;
 import hudson.model.Queue;
+import hudson.util.io.ArchiverFactory;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -53,7 +54,8 @@ public class ShelveProjectExecutable
         {
             final File projectRoot = project.getRootDir();
             OutputStream outputStream1 = createOutputStream( Hudson.getInstance().getRootDir(), project.getName() );
-            new FilePath( projectRoot ).zip( outputStream1, new FileFilter()
+            //new FilePath( projectRoot ).zip( outputStream1, new FileFilter()
+            new FilePath( projectRoot ).archive( ArchiverFactory.TARGZ, outputStream1, new FileFilter()
             {
                 public boolean accept( File file )
                 {
@@ -75,7 +77,7 @@ public class ShelveProjectExecutable
     {
         final File baseDir = new File( rootDir, "shelvedProjects" );
         baseDir.mkdirs();
-        final File archive = new File( baseDir, projectName + "-" + System.currentTimeMillis() + ".zip" );
+        final File archive = new File( baseDir, projectName + "-" + System.currentTimeMillis() + ".tgz" );
         return new FileOutputStream( archive );
     }
 

--- a/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelvedProjectsAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelvedProjectsAction.java
@@ -66,7 +66,7 @@ public class ShelvedProjectsAction
         shelvedProjectsDir.mkdirs();
 
         final Collection<File> shelvedProjectsArchives =
-            FileUtils.listFiles( shelvedProjectsDir, new String[]{"zip"}, false );
+            FileUtils.listFiles( shelvedProjectsDir, new String[]{"tgz","zip"}, false );
 
         List<ShelvedProject> projects = new LinkedList<ShelvedProject>();
         for ( File archive : shelvedProjectsArchives )

--- a/src/main/java/org/jvnet/hudson/plugins/shelveproject/UnshelveProjectExecutable.java
+++ b/src/main/java/org/jvnet/hudson/plugins/shelveproject/UnshelveProjectExecutable.java
@@ -37,10 +37,19 @@ public class UnshelveProjectExecutable
         {
             final File shelvedProjectArchive = getArchiveFile(shelvedProjectArchiveName);
             LOGGER.info( "Unshelving project [" + shelvedProjectArchiveName + "]." );
+			
             try
             {
-                new FilePath( shelvedProjectArchive ).unzip(
-                    new FilePath( new File( Hudson.getInstance().getRootDir(), "jobs" ) ) );
+				if ( shelvedProjectArchiveName.toLowerCase().matches("(.+)\\.zip") )
+				{
+					new FilePath( shelvedProjectArchive ).unzip(
+						new FilePath( new File( Hudson.getInstance().getRootDir(), "jobs" ) ) );
+				}
+				else 
+				{
+					new FilePath( shelvedProjectArchive ).untar(
+						new FilePath( new File( Hudson.getInstance().getRootDir(), "jobs" ) ), FilePath.TarCompression.GZIP );
+				}
                 shelvedProjectArchive.delete();
                 Hudson.getInstance().reload();
             }

--- a/src/main/java/org/jvnet/hudson/plugins/shelveproject/UnshelveProjectExecutable.java
+++ b/src/main/java/org/jvnet/hudson/plugins/shelveproject/UnshelveProjectExecutable.java
@@ -10,6 +10,8 @@ import java.io.File;
 import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.io.*;
+import java.net.*;
 
 public class UnshelveProjectExecutable
     implements Queue.Executable
@@ -51,7 +53,20 @@ public class UnshelveProjectExecutable
 						new FilePath( new File( Hudson.getInstance().getRootDir(), "jobs" ) ), FilePath.TarCompression.GZIP );
 				}
                 shelvedProjectArchive.delete();
-                Hudson.getInstance().reload();
+				
+				//Reload only the project that changed
+				String projectFolderName = shelvedProjectArchiveName.substring(0, shelvedProjectArchiveName.length()-4);
+				int indexHyphen = projectFolderName.lastIndexOf("-");
+				projectFolderName = projectFolderName.substring(0, indexHyphen);
+				String fileData = new String(loadData(Hudson.getInstance().getRootDir() + "\\jobs\\" + projectFolderName + "\\config.xml"));
+				String newConfigFileName = Hudson.getInstance().getRootDir() + "\\jobs\\" + projectFolderName + "\\unshelveConfig.txt";
+				writeToFile(fileData, newConfigFileName);
+				
+				FileInputStream fis = new FileInputStream(newConfigFileName);
+				Hudson.getInstance().createProjectFromXML(projectFolderName, fis);
+				fis.close();
+				File configFile = new File(newConfigFileName);
+				configFile.delete();
             }
             catch ( Exception e )
             {
@@ -79,6 +94,40 @@ public class UnshelveProjectExecutable
     {
         return -1; // impossible to estimate duration
     }
+	
+	public byte[] loadData(String fileName) {
+		byte[] returnVal = null;
+		FileInputStream fis = null;
+		try {
+			fis = new FileInputStream(fileName);
+			returnVal = new byte[fis.available()];
+			fis.read(returnVal);
+			fis.close();
+		} catch (Exception e) {
+			e.printStackTrace();
+			if (fis != null) {
+				try {
+					fis.close();
+				} catch (Exception e1) {
+					e1.printStackTrace();
+				}
+			}
+		}
+		return returnVal;
+    }
+	
+	boolean writeToFile(String data, String fileName) {
+        try {
+			java.io.FileOutputStream fos = new java.io.FileOutputStream(fileName);
+               fos.write(data.getBytes());
+	        fos.close();
+			return true;
+        } catch (Exception e) {
+			LOGGER.info("*** Could not write to file " + fileName + " ***");
+			e.printStackTrace(System.out);
+			return false;
+        }
+	}
 
     @Override
     public String toString()


### PR DESCRIPTION
Shelve plugin creates a corrupt archive when the project archived is greater than 4 gig compressed. Enabling 64 bit compression fixes this issue.
