### PR TITLE
[JENKINS-20922] Do not use the buildProgressBar component

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectExecutable.java
+++ b/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectExecutable.java
@@ -4,6 +4,7 @@ import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import hudson.FilePath;
 import hudson.model.AbstractProject;
 import hudson.model.BuildableItem;
+import hudson.model.Executor;
 import hudson.model.ItemGroup;
 import hudson.model.Queue;
 import jenkins.model.Jenkins;
@@ -51,6 +52,14 @@ public class ShelveProjectExecutable
 
     public long getEstimatedDuration() {
         return -1; // impossible to estimate duration
+    }
+
+    public String getTimestampString() {
+        Executor executor = Executor.of(this);
+        if(executor != null) {
+            return executor.getTimestampString();
+        }
+        return "N/A";
     }
 
     private boolean archiveProject() {

--- a/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectTask.java
@@ -47,7 +47,7 @@ public class ShelveProjectTask
 
     public String getName()
     {
-        return "Shelve " + item.getName();
+        return "Shelving " + item.getName();
     }
 
     public String getFullDisplayName()

--- a/src/main/resources/org/jvnet/hudson/plugins/shelveproject/ShelveProjectExecutable/executorCell.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/shelveproject/ShelveProjectExecutable/executorCell.jelly
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson" xmlns:l="/lib/layout">
+    <td class="pane">
+        <div style="white-space: normal">
+            <j:choose>
+                <j:when test="${h.hasPermission(it.parent, it.parent.READ)}">
+                    <l:breakable value="${it.parent.fullDisplayName}"/>
+                    <t:progressBar tooltip="Started ${it.timestampString} ago"
+                                   red="${it.parent.isBuildBlocked}"
+                                   pos="${it.estimatedDuration}"/>
+                </j:when>
+                <j:otherwise>
+                    <span>${%Unknown Task}</span>
+                </j:otherwise>
+            </j:choose>
+        </div>
+    </td>
+</j:jelly>

--- a/src/test/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectExecutableTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectExecutableTest.java
@@ -113,4 +113,12 @@ public class ShelveProjectExecutableTest {
         assertEquals("Not the expected number of metadata archives", 1, fileExplorerVisitor.getMetadataFileCount());
 
     }
+
+    @Issue("JENKINS-20922")
+    @Test
+    public void ifTheExecutableIsNotRunningTheTimeStampReturnsNA() throws IOException {
+        WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "my-pipeline");
+        ShelveProjectExecutable executable = new ShelveProjectExecutable(null, project);
+        assertEquals("Not the expected duration", "N/A", executable.getTimestampString());
+    }
 }


### PR DESCRIPTION
It appends /console at the end of the provided url, which doesn't exist
in the case of a shelve task.

Note: the test file had windows line ending, that explains the big diff. Only the latest was added.

@reviewbybees 