### PR TITLE
[JENKINS-66382] check the permission to shelve on the item itself

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectAction.java
@@ -30,8 +30,8 @@ public class ShelveProjectAction implements Action {
     return getShelveIconPath();
   }
 
-  private static String getShelveIconPath() {
-    return Jenkins.getInstance().hasPermission(SHELVE_PERMISSION) ? ACTION_ICON_PATH : null;
+  private String getShelveIconPath() {
+    return item.hasPermission(SHELVE_PERMISSION) ? ACTION_ICON_PATH : null;
   }
 
   public String getDisplayName() {
@@ -54,7 +54,7 @@ public class ShelveProjectAction implements Action {
   @POST
   public HttpResponse doShelveProject()
           throws IOException, ServletException {
-    Jenkins.getInstance().checkPermission(Item.DELETE);
+    item.checkPermission(Item.DELETE);
     if (!isShelvingProject()) {
       LOGGER.info("Shelving project [" + getItem().getName() + "].");
       // Shelving the project could take some time, so add it as a task

--- a/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectAction.java
@@ -1,5 +1,6 @@
 package org.jvnet.hudson.plugins.shelveproject;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Action;
 import hudson.model.Item;
 import hudson.security.Permission;
@@ -20,7 +21,7 @@ public class ShelveProjectAction implements Action {
   private boolean isShelvingProject;
   private static final String ACTION_ICON_PATH = "/plugin/shelve-project-plugin/icons/shelve-project-icon.png";
 
-  public ShelveProjectAction(Item item) {
+  public ShelveProjectAction(@NonNull Item item) {
     this.item = item;
     this.isShelvingProject = false;
   }

--- a/src/test/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectActionTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/shelveproject/ShelveProjectActionTest.java
@@ -1,9 +1,11 @@
 package org.jvnet.hudson.plugins.shelveproject;
 
+import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import java.io.IOException;
 import jenkins.model.Jenkins;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,21 +26,40 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @WithJenkins
 class ShelveProjectActionTest {
 
+    private FreeStyleProject shelveMe;
+    private FreeStyleProject keepMe;
+
     @BeforeEach
-    void setUp(JenkinsRule jenkinsRule) {
+    void setUp(JenkinsRule jenkinsRule) throws IOException {
+        shelveMe = jenkinsRule.createFreeStyleProject("shelveMe");
+        keepMe = jenkinsRule.createFreeStyleProject("keepMe");
         jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
         jenkinsRule.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
                 grant(Jenkins.ADMINISTER).everywhere().to("admin").
                 grant(Jenkins.READ, Item.DELETE).everywhere().to("developer").
                 grant(Jenkins.READ, Item.CREATE).everywhere().to("creator").
-                grant(Jenkins.READ).everywhere().to("reader"));
+                grant(Jenkins.READ).everywhere().to("reader").
+                grant(Jenkins.READ).everywhere().to("deleter").
+                grant(Item.DELETE).onPaths("shelveMe").to("deleter")
+        );
+    }
+
+    @Issue(("JENKINS-66382"))
+    @Test
+    void testShelveIconShouldBeVisibleForUserWithDeleteOnProjectOnly() {
+        try (ACLContext ignored = ACL.as2(User.get("deleter", true, new HashMap<>()).impersonate2())) {
+            assertNotNull(new ShelveProjectAction(shelveMe).getIconFileName(), "Shelve icon should be visible");
+        }
+        try (ACLContext ignored = ACL.as2(User.get("deleter", true, new HashMap<>()).impersonate2())) {
+            assertNull(new ShelveProjectAction(keepMe).getIconFileName(), "Shelve icon should not be visible");
+        }
     }
 
     @Issue("JENKINS-55462")
     @Test
     void testShelveIconShouldBeVisibleForAdmin() {
         try (ACLContext ignored = ACL.as2(User.get("admin", true, new HashMap<>()).impersonate2())) {
-            assertNotNull(new ShelveProjectAction(null).getIconFileName(), "Shelve icon should be visible");
+            assertNotNull(new ShelveProjectAction(shelveMe).getIconFileName(), "Shelve icon should be visible");
         }
     }
 
@@ -46,7 +67,7 @@ class ShelveProjectActionTest {
     @Test
     void testShelveIconShouldBeVisibleForUserWithDeleteRights() {
         try (ACLContext ignored = ACL.as2(User.get("developer", true, new HashMap<>()).impersonate2())) {
-            assertNotNull(new ShelveProjectAction(null).getIconFileName(), "Shelve icon should be visible");
+            assertNotNull(new ShelveProjectAction(shelveMe).getIconFileName(), "Shelve icon should be visible");
         }
     }
 
@@ -54,10 +75,10 @@ class ShelveProjectActionTest {
     @Test
     void testShelveIconShouldNotBeVisibleForOtherUsers() {
         try (ACLContext ignored = ACL.as2(User.get("creator", true, new HashMap<>()).impersonate2())) {
-            assertNull(new ShelveProjectAction(null).getIconFileName(), "Shelve icon should not be visible");
+            assertNull(new ShelveProjectAction(shelveMe).getIconFileName(), "Shelve icon should not be visible");
         }
         try (ACLContext ignored = ACL.as2(User.get("reader", true, new HashMap<>()).impersonate2())) {
-            assertNull(new ShelveProjectAction(null).getIconFileName(), "Shelve icon should not be visible");
+            assertNull(new ShelveProjectAction(shelveMe).getIconFileName(), "Shelve icon should not be visible");
         }
     }
 }


### PR DESCRIPTION
It should not be necessary to have delete permissions globally to be able to shelve an item. As long as one can delete an item one should be able to shelve it.

<!-- Please describe your pull request here. -->

### Testing done
Added a test.
Tested interactively that a user can shelve a folder with the folder having a project for which the user has no delete permissions (means can't shelve)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
